### PR TITLE
Fix leaflet dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
         "tests"
     ],
     "dependencies": {
-        "leaflet-dist": "0.7.x"
+        "leaflet": "0.7.x"
     }
 }


### PR DESCRIPTION
Leaflet extensions should have plain leaflet as dependency to prevent installation of multiple leaflet instances.
